### PR TITLE
malloc: fix it not working

### DIFF
--- a/kernel/init.cpp
+++ b/kernel/init.cpp
@@ -8,8 +8,6 @@
 #include "memory/malloc.h"
 
 
-extern kernie_heap heap;
-
 #define PIC1		    0x20		/* IO base address for master PIC */
 #define PIC2		    0xA0		/* IO base address for slave PIC */
 #define PIC1_COMMAND	PIC1
@@ -52,6 +50,6 @@ void init()
     parse();
 
     printf("[ %sOK %s] ramdisk parsed\n", Green, White);
-    
-    backbuffer = (unsigned char *)heap.malloc(buffer->width * buffer->height * sizeof(unsigned char));
+
+    backbuffer = (unsigned char *)kernie_heap::the()->malloc(buffer->width * buffer->height * sizeof(unsigned char));
 }

--- a/kernel/kernel.cpp
+++ b/kernel/kernel.cpp
@@ -39,16 +39,17 @@ extern "C" void _start(void)
     }
 
     comout("\033[2J \033[H");
-    init();
-
+    
     for (int i = 0; i < mmap.response->entry_count; i++)
     {
         uint64_t type = mmap.response->entries[i]->type;
         if (type == LIMINE_MEMMAP_USABLE)
         {
-            kernie_heap::the().init((unsigned char*)mmap.response->entries[i]->base);
+            kernie_heap::the()->init((unsigned char*)mmap.response->entries[i]->base);
         }
     }
+
+    init();
 
     comout("Hello COM\n");
 

--- a/kernel/memory/malloc.h
+++ b/kernel/memory/malloc.h
@@ -15,8 +15,8 @@ struct kernie_heap
 
     void init(unsigned char* addr);
 
-    static kernie_heap the() {
-        static kernie_heap me;
-        return me;
+    static kernie_heap* the(){
+		static kernie_heap me;
+		return &me;
     }
 };


### PR DESCRIPTION
kernel/init.cpp: use the actual kernie_heap singleton for the backbuffer allocation
kernel/kernel.cpp: initialize the kernie_heap singleton before running init()
kernel/memory/malloc.h: return a reference to the singleton rather than a copy